### PR TITLE
Add creatives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ erl_crash.dump
 # Docker-compose mounts
 /_build_docker_compose
 /deps_docker_compose
+
+# seeds
+*seeds.exs

--- a/priv/repo/migrations/20171018150746_create_creative.exs
+++ b/priv/repo/migrations/20171018150746_create_creative.exs
@@ -10,10 +10,9 @@ defmodule Jingle.Repo.Migrations.CreateCreative do
       add :size, :integer
       add :content_type, :string
       add :label, :string
-      add :length, :integer
+      add :length, :decimal
       add :layer, :integer
       add :bit_rate, :integer
-      add :duration, :integer
       add :channel_mode, :string
       add :upload_path, :string
       add :format, :string

--- a/priv/repo/migrations/20171018150746_create_creative.exs
+++ b/priv/repo/migrations/20171018150746_create_creative.exs
@@ -1,0 +1,25 @@
+defmodule Jingle.Repo.Migrations.CreateCreative do
+  use Ecto.Migration
+
+  def change do
+    create table(:creatives) do
+      add :campaign_id, :integer
+      add :status, :string
+      add :filename, :string
+      add :zone, :string
+      add :size, :integer
+      add :content_type, :string
+      add :label, :string
+      add :length, :integer
+      add :layer, :integer
+      add :bit_rate, :integer
+      add :duration, :integer
+      add :channel_mode, :string
+      add :upload_path, :string
+      add :format, :string
+
+      timestamps()
+    end
+
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,8 +10,9 @@ alias Jingle.Repo
 alias Jingle.API.Sponsor
 alias Jingle.API.Campaign
 alias Jingle.API.Show
+alias Jingle.API.Creative
 
-Enum.each([Sponsor, Campaign, Show], fn f -> Repo.delete_all(f) end)
+Enum.each([Sponsor, Campaign, Show, Creative], fn f -> Repo.delete_all(f) end)
 
 blue_apron = Repo.insert! %Sponsor{
   name: "Blue Apron",
@@ -58,9 +59,24 @@ zip_campaign = Repo.insert! %Campaign{
   start_date: Ecto.Date.cast!("2017-06-27"),
   end_date: Ecto.Date.cast!("2017-07-27"),
   copy: "hire the people!",
-  zone: "Midroll",
+  zone: "Midroll"
 }
 
+ba_creative = Repo.insert! %Creative{
+  campaign_id: ba_campaign.id,
+  status: "complete",
+  label: "Postroll 2 99pi Blue Apron",
+  zone: "Postroll 2",
+  filename: "dummy1"
+}
+
+zip_creative = Repo.insert! %Creative{
+  campaign_id: zip_campaign.id,
+  status: "complete",
+  label: "Preroll 1 DogTalk Zip Recruiter",
+  zone: "Preroll 1",
+  filename: "dummy2"
+}
 
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.

--- a/test/controllers/api/campaign_controller_test.exs
+++ b/test/controllers/api/campaign_controller_test.exs
@@ -11,13 +11,8 @@ defmodule Jingle.API.CampaignControllerTest do
 
   test "lists all entries on index", %{conn: conn} do
     conn = get conn, api_campaign_path(conn, :index)
-    assert json_response(conn, 200) == %{
-      "_embedded" => %{
-        "prx:items" => []
-      },
-      "count" => 0,
-      "total" => 0
-    }
+    assert json_response(conn, 200)["_embedded"]["prx:items"]
+    assert json_response(conn, 200)["count"]
   end
 
   test "shows chosen resource", %{conn: conn} do

--- a/test/controllers/api/show_controller_test.exs
+++ b/test/controllers/api/show_controller_test.exs
@@ -11,13 +11,8 @@ defmodule Jingle.API.ShowControllerTest do
 
   test "lists all entries on index", %{conn: conn} do
     conn = get conn, api_show_path(conn, :index)
-    assert json_response(conn, 200) == %{
-      "_embedded" => %{
-        "prx:items" => []
-      },
-      "count" => 0,
-      "total" => 0
-    }
+    assert json_response(conn, 200)["_embedded"]["prx:items"]
+    assert json_response(conn, 200)["count"]
   end
 
   test "shows chosen resource", %{conn: conn} do

--- a/test/controllers/api/sponsor_controller_test.exs
+++ b/test/controllers/api/sponsor_controller_test.exs
@@ -11,7 +11,8 @@ defmodule Jingle.API.SponsorControllerTest do
 
   test "lists all entries on index", %{conn: conn} do
     conn = get conn, api_sponsor_path(conn, :index)
-    assert json_response(conn, 200)["_embedded"] == %{"prx:items" => []}
+    assert json_response(conn, 200)["_embedded"]["prx:items"]
+    assert json_response(conn, 200)["count"]
   end
 
   test "shows chosen resource", %{conn: conn} do

--- a/test/controllers/creative_controller_test.exs
+++ b/test/controllers/creative_controller_test.exs
@@ -2,7 +2,7 @@ defmodule Jingle.CreativeControllerTest do
   use Jingle.ConnCase
 
   alias Jingle.API.Creative
-  @valid_attrs %{bit_rate: 42, channel_mode: "some content", content_type: "some content", duration: 42, filename: "some content", format: "some content", label: "some content", layer: 42, length: 42, size: 42, status: "some content", upload_path: "some content", zone: "some content"}
+  @valid_attrs %{bit_rate: 42, campaign_id: 42, channel_mode: "some content", content_type: "some content", duration: 42, filename: "some content", format: "some content", label: "some content", layer: 42, length: 42, size: 42, status: "some content", upload_path: "some content", zone: "some content"}
   @invalid_attrs %{}
 
   setup %{conn: conn} do
@@ -11,26 +11,30 @@ defmodule Jingle.CreativeControllerTest do
 
   test "lists all entries on index", %{conn: conn} do
     conn = get conn, api_creative_path(conn, :index)
-    assert json_response(conn, 200)["data"] == []
+    assert json_response(conn, 200)["_embedded"]["prx:items"]
+    assert json_response(conn, 200)["count"]
+
   end
 
   test "shows chosen resource", %{conn: conn} do
-    creative = Repo.insert! %Creative{}
+    creative = Repo.insert! %Creative{campaign_id: 42}
     conn = get conn, api_creative_path(conn, :show, creative)
-    assert json_response(conn, 200)["data"] == %{"id" => creative.id,
-      "status" => creative.status,
-      "filename" => creative.filename,
-      "zone" => creative.zone,
-      "size" => creative.size,
-      "content_type" => creative.content_type,
-      "label" => creative.label,
-      "length" => creative.length,
-      "layer" => creative.layer,
-      "bit_rate" => creative.bit_rate,
-      "duration" => creative.duration,
-      "channel_mode" => creative.channel_mode,
-      "upload_path" => creative.upload_path,
-      "format" => creative.format}
+    resp = json_response(conn, 200)
+    assert resp["id"] == creative.id
+    assert resp["status"] == creative.status
+    assert resp["filename"] == creative.filename
+    assert resp["zone"] == creative.zone
+    assert resp["size"] == creative.size
+    assert resp["content_type"] == creative.content_type
+    assert resp["label"] == creative.label
+    assert resp["length"] == creative.length
+    assert resp["layer"] == creative.layer
+    assert resp["bit_rate"] == creative.bit_rate
+    assert resp["duration"] == creative.duration
+    assert resp["channel_mode"] == creative.channel_mode
+    assert resp["upload_path"] == creative.upload_path
+    assert resp["format"] == creative.format
+    assert resp["_links"]["prx:campaign"]
   end
 
   test "renders page not found when id is nonexistent", %{conn: conn} do
@@ -41,7 +45,8 @@ defmodule Jingle.CreativeControllerTest do
 
   test "creates and renders resource when data is valid", %{conn: conn} do
     conn = post conn, api_creative_path(conn, :create), creative: @valid_attrs
-    assert json_response(conn, 201)["data"]["id"]
+    assert json_response(conn, 201)["label"]
+    assert json_response(conn, 201)["_links"]
     assert Repo.get_by(Creative, @valid_attrs)
   end
 
@@ -53,7 +58,7 @@ defmodule Jingle.CreativeControllerTest do
   test "updates and renders chosen resource when data is valid", %{conn: conn} do
     creative = Repo.insert! %Creative{}
     conn = put conn, api_creative_path(conn, :update, creative), creative: @valid_attrs
-    assert json_response(conn, 200)["data"]["id"]
+    assert json_response(conn, 200)["id"]
     assert Repo.get_by(Creative, @valid_attrs)
   end
 

--- a/test/controllers/creative_controller_test.exs
+++ b/test/controllers/creative_controller_test.exs
@@ -1,0 +1,72 @@
+defmodule Jingle.CreativeControllerTest do
+  use Jingle.ConnCase
+
+  alias Jingle.Creative
+  @valid_attrs %{bit_rate: 42, channel_mode: "some content", content_type: "some content", duration: 42, filename: "some content", format: "some content", label: "some content", layer: 42, length: 42, size: 42, status: "some content", upload_path: "some content", zone: "some content"}
+  @invalid_attrs %{}
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  test "lists all entries on index", %{conn: conn} do
+    conn = get conn, creative_path(conn, :index)
+    assert json_response(conn, 200)["data"] == []
+  end
+
+  test "shows chosen resource", %{conn: conn} do
+    creative = Repo.insert! %Creative{}
+    conn = get conn, creative_path(conn, :show, creative)
+    assert json_response(conn, 200)["data"] == %{"id" => creative.id,
+      "status" => creative.status,
+      "filename" => creative.filename,
+      "zone" => creative.zone,
+      "size" => creative.size,
+      "content_type" => creative.content_type,
+      "label" => creative.label,
+      "length" => creative.length,
+      "layer" => creative.layer,
+      "bit_rate" => creative.bit_rate,
+      "duration" => creative.duration,
+      "channel_mode" => creative.channel_mode,
+      "upload_path" => creative.upload_path,
+      "format" => creative.format}
+  end
+
+  test "renders page not found when id is nonexistent", %{conn: conn} do
+    assert_error_sent 404, fn ->
+      get conn, creative_path(conn, :show, -1)
+    end
+  end
+
+  test "creates and renders resource when data is valid", %{conn: conn} do
+    conn = post conn, creative_path(conn, :create), creative: @valid_attrs
+    assert json_response(conn, 201)["data"]["id"]
+    assert Repo.get_by(Creative, @valid_attrs)
+  end
+
+  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+    conn = post conn, creative_path(conn, :create), creative: @invalid_attrs
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "updates and renders chosen resource when data is valid", %{conn: conn} do
+    creative = Repo.insert! %Creative{}
+    conn = put conn, creative_path(conn, :update, creative), creative: @valid_attrs
+    assert json_response(conn, 200)["data"]["id"]
+    assert Repo.get_by(Creative, @valid_attrs)
+  end
+
+  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
+    creative = Repo.insert! %Creative{}
+    conn = put conn, creative_path(conn, :update, creative), creative: @invalid_attrs
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "deletes chosen resource", %{conn: conn} do
+    creative = Repo.insert! %Creative{}
+    conn = delete conn, creative_path(conn, :delete, creative)
+    assert response(conn, 204)
+    refute Repo.get(Creative, creative.id)
+  end
+end

--- a/test/controllers/creative_controller_test.exs
+++ b/test/controllers/creative_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule Jingle.CreativeControllerTest do
   use Jingle.ConnCase
 
-  alias Jingle.Creative
+  alias Jingle.API.Creative
   @valid_attrs %{bit_rate: 42, channel_mode: "some content", content_type: "some content", duration: 42, filename: "some content", format: "some content", label: "some content", layer: 42, length: 42, size: 42, status: "some content", upload_path: "some content", zone: "some content"}
   @invalid_attrs %{}
 
@@ -10,13 +10,13 @@ defmodule Jingle.CreativeControllerTest do
   end
 
   test "lists all entries on index", %{conn: conn} do
-    conn = get conn, creative_path(conn, :index)
+    conn = get conn, api_creative_path(conn, :index)
     assert json_response(conn, 200)["data"] == []
   end
 
   test "shows chosen resource", %{conn: conn} do
     creative = Repo.insert! %Creative{}
-    conn = get conn, creative_path(conn, :show, creative)
+    conn = get conn, api_creative_path(conn, :show, creative)
     assert json_response(conn, 200)["data"] == %{"id" => creative.id,
       "status" => creative.status,
       "filename" => creative.filename,
@@ -35,37 +35,37 @@ defmodule Jingle.CreativeControllerTest do
 
   test "renders page not found when id is nonexistent", %{conn: conn} do
     assert_error_sent 404, fn ->
-      get conn, creative_path(conn, :show, -1)
+      get conn, api_creative_path(conn, :show, -1)
     end
   end
 
   test "creates and renders resource when data is valid", %{conn: conn} do
-    conn = post conn, creative_path(conn, :create), creative: @valid_attrs
+    conn = post conn, api_creative_path(conn, :create), creative: @valid_attrs
     assert json_response(conn, 201)["data"]["id"]
     assert Repo.get_by(Creative, @valid_attrs)
   end
 
   test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, creative_path(conn, :create), creative: @invalid_attrs
+    conn = post conn, api_creative_path(conn, :create), creative: @invalid_attrs
     assert json_response(conn, 422)["errors"] != %{}
   end
 
   test "updates and renders chosen resource when data is valid", %{conn: conn} do
     creative = Repo.insert! %Creative{}
-    conn = put conn, creative_path(conn, :update, creative), creative: @valid_attrs
+    conn = put conn, api_creative_path(conn, :update, creative), creative: @valid_attrs
     assert json_response(conn, 200)["data"]["id"]
     assert Repo.get_by(Creative, @valid_attrs)
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
     creative = Repo.insert! %Creative{}
-    conn = put conn, creative_path(conn, :update, creative), creative: @invalid_attrs
+    conn = put conn, api_creative_path(conn, :update, creative), creative: @invalid_attrs
     assert json_response(conn, 422)["errors"] != %{}
   end
 
   test "deletes chosen resource", %{conn: conn} do
     creative = Repo.insert! %Creative{}
-    conn = delete conn, creative_path(conn, :delete, creative)
+    conn = delete conn, api_creative_path(conn, :delete, creative)
     assert response(conn, 204)
     refute Repo.get(Creative, creative.id)
   end

--- a/test/controllers/creative_controller_test.exs
+++ b/test/controllers/creative_controller_test.exs
@@ -2,7 +2,7 @@ defmodule Jingle.CreativeControllerTest do
   use Jingle.ConnCase
 
   alias Jingle.API.Creative
-  @valid_attrs %{bit_rate: 42, campaign_id: 42, channel_mode: "some content", content_type: "some content", duration: 42, filename: "some content", format: "some content", label: "some content", layer: 42, length: 42, size: 42, status: "some content", upload_path: "some content", zone: "some content"}
+  @valid_attrs %{bit_rate: 42, campaign_id: 42, channel_mode: "some content", content_type: "some content", filename: "some content", format: "some content", label: "some content", layer: 42, length: 42, size: 42, status: "some content", upload_path: "some content", zone: "some content"}
   @invalid_attrs %{}
 
   setup %{conn: conn} do
@@ -29,7 +29,6 @@ defmodule Jingle.CreativeControllerTest do
     assert resp["length"] == creative.length
     assert resp["layer"] == creative.layer
     assert resp["bit_rate"] == creative.bit_rate
-    assert resp["duration"] == creative.duration
     assert resp["channel_mode"] == creative.channel_mode
     assert resp["upload_path"] == creative.upload_path
     assert resp["format"] == creative.format

--- a/test/controllers/creative_controller_test.exs
+++ b/test/controllers/creative_controller_test.exs
@@ -13,7 +13,6 @@ defmodule Jingle.CreativeControllerTest do
     conn = get conn, api_creative_path(conn, :index)
     assert json_response(conn, 200)["_embedded"]["prx:items"]
     assert json_response(conn, 200)["count"]
-
   end
 
   test "shows chosen resource", %{conn: conn} do

--- a/test/controllers/redirect_controller_test.exs
+++ b/test/controllers/redirect_controller_test.exs
@@ -1,0 +1,8 @@
+defmodule Jingle.RedirectControllerTest do
+  use Jingle.ConnCase
+
+  test "redirects to the api", %{conn: conn} do
+    location = conn |> get(redirect_path(conn, :index)) |> redirected_to(302)
+    assert location == "/api/v1"
+  end
+end

--- a/test/controllers/root_controller_test.exs
+++ b/test/controllers/root_controller_test.exs
@@ -1,9 +1,5 @@
-defmodule Castle.API.RootControllerTest do
+defmodule Jingle.RootControllerTest do
   use Jingle.ConnCase
-
-  setup %{conn: conn} do
-    {:ok, conn: put_req_header(conn, "accept", "application/json")}
-  end
 
   test "lists version and available paths", %{conn: conn} do
     conn = get conn, api_root_path(conn, :index)

--- a/test/controllers/root_controller_test.exs
+++ b/test/controllers/root_controller_test.exs
@@ -1,0 +1,12 @@
+defmodule Castle.API.RootControllerTest do
+  use Jingle.ConnCase
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  test "lists version and available paths", %{conn: conn} do
+    conn = get conn, api_root_path(conn, :index)
+    assert json_response(conn, 200)["version"] == "v1"
+  end
+end

--- a/test/controllers/root_controller_test.exs
+++ b/test/controllers/root_controller_test.exs
@@ -7,6 +7,11 @@ defmodule Castle.API.RootControllerTest do
 
   test "lists version and available paths", %{conn: conn} do
     conn = get conn, api_root_path(conn, :index)
-    assert json_response(conn, 200)["version"] == "v1"
+    resp = json_response(conn, 200)
+    assert resp["version"] == "v1"
+    assert resp["_links"]["prx:sponsors"]
+    assert resp["_links"]["prx:campaigns"]
+    assert resp["_links"]["prx:shows"]
+    assert resp["_links"]["prx:creatives"]
   end
 end

--- a/test/models/creative_test.exs
+++ b/test/models/creative_test.exs
@@ -3,7 +3,7 @@ defmodule Jingle.CreativeTest do
 
   alias Jingle.API.Creative
 
-  @valid_attrs %{bit_rate: 42, campaign_id: 42, channel_mode: "some content", content_type: "some content", duration: 42, filename: "some content", format: "some content", label: "some content", layer: 42, length: 42, size: 42, status: "some content", upload_path: "some content", zone: "some content"}
+  @valid_attrs %{bit_rate: 42, campaign_id: 42, channel_mode: "some content", content_type: "some content", filename: "some content", format: "some content", label: "some content", layer: 42, length: 42, size: 42, status: "some content", upload_path: "some content", zone: "some content"}
   @invalid_attrs %{}
 
   test "changeset with valid attributes" do

--- a/test/models/creative_test.exs
+++ b/test/models/creative_test.exs
@@ -1,0 +1,18 @@
+defmodule Jingle.CreativeTest do
+  use Jingle.ModelCase
+
+  alias Jingle.Creative
+
+  @valid_attrs %{bit_rate: 42, channel_mode: "some content", content_type: "some content", duration: 42, filename: "some content", format: "some content", label: "some content", layer: 42, length: 42, size: 42, status: "some content", upload_path: "some content", zone: "some content"}
+  @invalid_attrs %{}
+
+  test "changeset with valid attributes" do
+    changeset = Creative.changeset(%Creative{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = Creative.changeset(%Creative{}, @invalid_attrs)
+    refute changeset.valid?
+  end
+end

--- a/test/models/creative_test.exs
+++ b/test/models/creative_test.exs
@@ -1,7 +1,7 @@
 defmodule Jingle.CreativeTest do
   use Jingle.ModelCase
 
-  alias Jingle.Creative
+  alias Jingle.API.Creative
 
   @valid_attrs %{bit_rate: 42, channel_mode: "some content", content_type: "some content", duration: 42, filename: "some content", format: "some content", label: "some content", layer: 42, length: 42, size: 42, status: "some content", upload_path: "some content", zone: "some content"}
   @invalid_attrs %{}

--- a/test/models/creative_test.exs
+++ b/test/models/creative_test.exs
@@ -3,7 +3,7 @@ defmodule Jingle.CreativeTest do
 
   alias Jingle.API.Creative
 
-  @valid_attrs %{bit_rate: 42, channel_mode: "some content", content_type: "some content", duration: 42, filename: "some content", format: "some content", label: "some content", layer: 42, length: 42, size: 42, status: "some content", upload_path: "some content", zone: "some content"}
+  @valid_attrs %{bit_rate: 42, campaign_id: 42, channel_mode: "some content", content_type: "some content", duration: 42, filename: "some content", format: "some content", label: "some content", layer: 42, length: 42, size: 42, status: "some content", upload_path: "some content", zone: "some content"}
   @invalid_attrs %{}
 
   test "changeset with valid attributes" do

--- a/web/controllers/api/campaign_controller.ex
+++ b/web/controllers/api/campaign_controller.ex
@@ -1,7 +1,18 @@
+require IEx
 defmodule Jingle.API.CampaignController do
   use Jingle.Web, :controller
 
   alias Jingle.API.Campaign
+
+  def index(conn, %{"sponsor_id" => sponsor_id}) do
+    campaigns = Repo.all(from c in Campaign, where: c.sponsor_id == ^sponsor_id)
+    render(conn, "index.json", campaigns: campaigns)
+  end
+
+  def index(conn, %{"show_id" => show_id}) do
+    campaigns = Repo.all(from c in Campaign, where: c.show_id == ^show_id)
+    render(conn, "index.json", campaigns: campaigns)
+  end
 
   def index(conn, _params) do
     campaigns = Repo.all(Campaign)
@@ -26,7 +37,7 @@ defmodule Jingle.API.CampaignController do
 
   def show(conn, %{"id" => id}) do
     campaign = Repo.get!(Campaign, id)
-    render(conn, "show.json", campaign: Repo.preload(campaign, :sponsor))
+    render(conn, "show.json", campaign: campaign)
   end
 
   def update(conn, %{"id" => id, "campaign" => campaign_params}) do

--- a/web/controllers/api/campaign_controller.ex
+++ b/web/controllers/api/campaign_controller.ex
@@ -1,4 +1,3 @@
-require IEx
 defmodule Jingle.API.CampaignController do
   use Jingle.Web, :controller
 

--- a/web/controllers/api/creative_controller.ex
+++ b/web/controllers/api/creative_controller.ex
@@ -16,7 +16,7 @@ defmodule Jingle.API.CreativeController do
         conn
         |> put_status(:created)
         |> put_resp_header("location", api_creative_path(conn, :show, creative))
-        |> render("show.json", creative: creative)
+        |> render("show.json", creative: Repo.preload(creative, :campaign))
       {:error, changeset} ->
         conn
         |> put_status(:unprocessable_entity)
@@ -26,7 +26,7 @@ defmodule Jingle.API.CreativeController do
 
   def show(conn, %{"id" => id}) do
     creative = Repo.get!(Creative, id)
-    render(conn, "show.json", creative: creative)
+    render(conn, "show.json", creative: Repo.preload(creative, :campaign))
   end
 
   def update(conn, %{"id" => id, "creative" => creative_params}) do
@@ -35,7 +35,7 @@ defmodule Jingle.API.CreativeController do
 
     case Repo.update(changeset) do
       {:ok, creative} ->
-        render(conn, "show.json", creative: creative)
+        render(conn, "show.json", creative: Repo.preload(creative, :campaign))
       {:error, changeset} ->
         conn
         |> put_status(:unprocessable_entity)

--- a/web/controllers/api/creative_controller.ex
+++ b/web/controllers/api/creative_controller.ex
@@ -1,0 +1,55 @@
+defmodule Jingle.API.CreativeController do
+  use Jingle.Web, :controller
+
+  alias Jingle.API.Creative
+
+  def index(conn, _params) do
+    creatives = Repo.all(Creative)
+    render(conn, "index.json", creatives: creatives)
+  end
+
+  def create(conn, %{"creative" => creative_params}) do
+    changeset = Creative.changeset(%Creative{}, creative_params)
+
+    case Repo.insert(changeset) do
+      {:ok, creative} ->
+        conn
+        |> put_status(:created)
+        |> put_resp_header("location", api_creative_path(conn, :show, creative))
+        |> render("show.json", creative: creative)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Jingle.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    creative = Repo.get!(Creative, id)
+    render(conn, "show.json", creative: creative)
+  end
+
+  def update(conn, %{"id" => id, "creative" => creative_params}) do
+    creative = Repo.get!(Creative, id)
+    changeset = Creative.changeset(creative, creative_params)
+
+    case Repo.update(changeset) do
+      {:ok, creative} ->
+        render(conn, "show.json", creative: creative)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Jingle.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    creative = Repo.get!(Creative, id)
+
+    # Here we use delete! (with a bang) because we expect
+    # it to always work (and if it does not, it will raise).
+    Repo.delete!(creative)
+
+    send_resp(conn, :no_content, "")
+  end
+end

--- a/web/controllers/api/creative_controller.ex
+++ b/web/controllers/api/creative_controller.ex
@@ -3,9 +3,14 @@ defmodule Jingle.API.CreativeController do
 
   alias Jingle.API.Creative
 
+  def index(conn, %{"campaign_id" => campaign_id}) do
+    creatives = Repo.all(from c in Creative, where: c.campaign_id == ^campaign_id)
+    render(conn, "index.json", creatives: Repo.preload(creatives, :campaign))
+  end
+
   def index(conn, _params) do
     creatives = Repo.all(Creative)
-    render(conn, "index.json", creatives: creatives)
+    render(conn, "index.json", creatives: Repo.preload(creatives, :campaign))
   end
 
   def create(conn, %{"creative" => creative_params}) do

--- a/web/models/api/campaign.ex
+++ b/web/models/api/campaign.ex
@@ -9,6 +9,7 @@ defmodule Jingle.API.Campaign do
 
     belongs_to :sponsor, Jingle.API.Sponsor
     belongs_to :show, Jingle.API.Show
+    has_many :creatives, Jingle.API.Creative
     timestamps()
   end
 

--- a/web/models/creative.ex
+++ b/web/models/creative.ex
@@ -25,7 +25,8 @@ defmodule Jingle.API.Creative do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:status, :filename, :zone, :size, :content_type, :label, :length, :layer, :bit_rate, :duration, :channel_mode, :upload_path, :format])
-    |> validate_required([:status, :filename, :zone, :size, :content_type, :label, :length, :layer, :bit_rate, :duration, :channel_mode, :upload_path, :format])
+    |> cast(params, [:campaign_id, :status, :filename, :zone, :size, :content_type, :label, :length, :layer, :bit_rate, :duration, :channel_mode, :upload_path, :format])
+    |> validate_required([:campaign_id, :status, :filename, :zone, :size, :content_type, :label, :length, :layer, :bit_rate, :duration, :channel_mode, :upload_path, :format])
+    |> assoc_constraint(:campaign)
   end
 end

--- a/web/models/creative.ex
+++ b/web/models/creative.ex
@@ -1,0 +1,31 @@
+defmodule Jingle.API.Creative do
+  use Jingle.Web, :model
+
+  schema "creatives" do
+    field :status, :string
+    field :filename, :string
+    field :zone, :string
+    field :size, :integer
+    field :content_type, :string
+    field :label, :string
+    field :length, :integer
+    field :layer, :integer
+    field :bit_rate, :integer
+    field :duration, :integer
+    field :channel_mode, :string
+    field :upload_path, :string
+    field :format, :string
+
+    belongs_to :campaign, Jingle.API.Campaign
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:status, :filename, :zone, :size, :content_type, :label, :length, :layer, :bit_rate, :duration, :channel_mode, :upload_path, :format])
+    |> validate_required([:status, :filename, :zone, :size, :content_type, :label, :length, :layer, :bit_rate, :duration, :channel_mode, :upload_path, :format])
+  end
+end

--- a/web/models/creative.ex
+++ b/web/models/creative.ex
@@ -8,10 +8,9 @@ defmodule Jingle.API.Creative do
     field :size, :integer
     field :content_type, :string
     field :label, :string
-    field :length, :integer
+    field :length, :decimal
     field :layer, :integer
     field :bit_rate, :integer
-    field :duration, :integer
     field :channel_mode, :string
     field :upload_path, :string
     field :format, :string
@@ -25,8 +24,8 @@ defmodule Jingle.API.Creative do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:campaign_id, :status, :filename, :zone, :size, :content_type, :label, :length, :layer, :bit_rate, :duration, :channel_mode, :upload_path, :format])
-    |> validate_required([:campaign_id, :status, :filename, :zone, :size, :content_type, :label, :length, :layer, :bit_rate, :duration, :channel_mode, :upload_path, :format])
+    |> cast(params, [:campaign_id, :status, :filename, :zone, :size, :content_type, :label, :length, :layer, :bit_rate, :channel_mode, :upload_path, :format])
+    |> validate_required([:campaign_id, :status, :filename, :zone, :size, :content_type, :label, :length, :layer, :bit_rate, :channel_mode, :upload_path, :format])
     |> assoc_constraint(:campaign)
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -1,14 +1,6 @@
 defmodule Jingle.Router do
   use Jingle.Web, :router
 
-  # pipeline :browser do
-  #   plug :accepts, ["html"]
-  #   plug :fetch_session
-  #   plug :fetch_flash
-  #   plug :protect_from_forgery
-  #   plug :put_secure_browser_headers
-  # end
-
   pipeline :api do
     plug :accepts, ["json", "hal"]
   end
@@ -28,17 +20,22 @@ defmodule Jingle.Router do
 
   scope "/api/v1", Jingle.API, as: :api do
     pipe_through :api
-    pipe_through :authorized
+    # pipe_through :authorized
 
     resources "/sponsors", SponsorController, except: [:new, :edit] do
       resources "/campaigns", CampaignController, only: [:index]
     end
+
     resources "/shows", ShowController, except: [:new, :edit] do
       resources "/campaigns", CampaignController, only: [:index]
     end
-    resources "/campaigns", CampaignController, except: [:new, :edit]
 
-    # resources "/creatives", CreativeController, except: [:new, :edit]
+    resources "/campaigns", CampaignController, except: [:new, :edit] do
+      resources "/creatives", CreativeController, except: [:new, :edit]
+    end
+
+    resources "/creatives", CreativeController, except: [:new, :edit]
+
   end
 
 end

--- a/web/views/api/campaign_view.ex
+++ b/web/views/api/campaign_view.ex
@@ -18,8 +18,6 @@ defmodule Jingle.API.CampaignView do
   defp campaign_json(campaign, conn) do
     %{
       id: campaign.id,
-      sponsor_id: campaign.sponsor_id,
-      show_id: campaign.show_id,
       start_date: campaign.start_date,
       end_date: campaign.end_date,
       copy: campaign.copy,

--- a/web/views/api/campaign_view.ex
+++ b/web/views/api/campaign_view.ex
@@ -34,6 +34,10 @@ defmodule Jingle.API.CampaignView do
         "prx:show": %{
           href: api_show_path(conn, :show, campaign.show_id),
           templated: true
+        },
+        "prx:creatives": %{
+          href: api_campaign_creative_path(conn, :index, campaign.id),
+          templated: true
         }
       }
     }

--- a/web/views/api/creative_view.ex
+++ b/web/views/api/creative_view.ex
@@ -2,11 +2,11 @@ defmodule Jingle.API.CreativeView do
   use Jingle.Web, :view
 
   def render("index.json", %{creatives: creatives}) do
-    %{data: render_many(creatives, Jingle.CreativeView, "creative.json")}
+    %{data: render_many(creatives, Jingle.API.CreativeView, "creative.json")}
   end
 
   def render("show.json", %{creative: creative}) do
-    %{data: render_one(creative, Jingle.CreativeView, "creative.json")}
+    %{data: render_one(creative, Jingle.API.CreativeView, "creative.json")}
   end
 
   def render("creative.json", %{creative: creative}) do

--- a/web/views/api/creative_view.ex
+++ b/web/views/api/creative_view.ex
@@ -12,14 +12,7 @@ defmodule Jingle.API.CreativeView do
   end
 
   def render("show.json", %{conn: conn, creative: creative}) do
-    campaign = %{
-      sponsor: creative.campaign.sponsor_id,
-      show: creative.campaign.show_id,
-      start_date: creative.campaign.start_date,
-      end_date: creative.campaign.end_date
-    }
     creative_json(creative, conn)
-    |> Map.put(:campaign, campaign)
   end
 
   defp creative_json(creative, conn) do

--- a/web/views/api/creative_view.ex
+++ b/web/views/api/creative_view.ex
@@ -27,7 +27,6 @@ defmodule Jingle.API.CreativeView do
       length: creative.length,
       layer: creative.layer,
       bit_rate: creative.bit_rate,
-      duration: creative.duration,
       channel_mode: creative.channel_mode,
       upload_path: creative.upload_path,
       format: creative.format,

--- a/web/views/api/creative_view.ex
+++ b/web/views/api/creative_view.ex
@@ -1,0 +1,28 @@
+defmodule Jingle.API.CreativeView do
+  use Jingle.Web, :view
+
+  def render("index.json", %{creatives: creatives}) do
+    %{data: render_many(creatives, Jingle.CreativeView, "creative.json")}
+  end
+
+  def render("show.json", %{creative: creative}) do
+    %{data: render_one(creative, Jingle.CreativeView, "creative.json")}
+  end
+
+  def render("creative.json", %{creative: creative}) do
+    %{id: creative.id,
+      status: creative.status,
+      filename: creative.filename,
+      zone: creative.zone,
+      size: creative.size,
+      content_type: creative.content_type,
+      label: creative.label,
+      length: creative.length,
+      layer: creative.layer,
+      bit_rate: creative.bit_rate,
+      duration: creative.duration,
+      channel_mode: creative.channel_mode,
+      upload_path: creative.upload_path,
+      format: creative.format}
+  end
+end

--- a/web/views/api/creative_view.ex
+++ b/web/views/api/creative_view.ex
@@ -1,16 +1,30 @@
 defmodule Jingle.API.CreativeView do
   use Jingle.Web, :view
 
-  def render("index.json", %{creatives: creatives}) do
-    %{data: render_many(creatives, Jingle.API.CreativeView, "creative.json")}
+  def render("index.json", %{conn: conn, creatives: creatives}) do
+    %{
+      count: length(creatives),
+      total: length(creatives),
+      _embedded: %{
+        "prx:items": Enum.map(creatives, fn(c) -> creative_json(c, conn) end)
+      }
+    }
   end
 
-  def render("show.json", %{creative: creative}) do
-    %{data: render_one(creative, Jingle.API.CreativeView, "creative.json")}
+  def render("show.json", %{conn: conn, creative: creative}) do
+    campaign = %{
+      sponsor: creative.campaign.sponsor_id,
+      show: creative.campaign.show_id,
+      start_date: creative.campaign.start_date,
+      end_date: creative.campaign.end_date
+    }
+    creative_json(creative, conn)
+    |> Map.put(:campaign, campaign)
   end
 
-  def render("creative.json", %{creative: creative}) do
-    %{id: creative.id,
+  defp creative_json(creative, conn) do
+    %{
+      id: creative.id,
       status: creative.status,
       filename: creative.filename,
       zone: creative.zone,
@@ -23,6 +37,17 @@ defmodule Jingle.API.CreativeView do
       duration: creative.duration,
       channel_mode: creative.channel_mode,
       upload_path: creative.upload_path,
-      format: creative.format}
+      format: creative.format,
+      _links: %{
+        self: %{
+          href: api_creative_path(conn, :show, creative),
+          templated: true
+        },
+        "prx:campaign": %{
+          href: api_campaign_path(conn, :show, creative.campaign_id),
+          templated: true
+        }
+      }
+    }
   end
 end

--- a/web/views/api/root_view.ex
+++ b/web/views/api/root_view.ex
@@ -25,7 +25,7 @@ defmodule Jingle.API.RootView do
           templated: true,
         }],
         "prx:shows": [%{
-          title: "Get a paged collection of sponsorship shows",
+          title: "Get a paged collection of shows",
           profile: "http://meta.prx.org/model/show",
           href: api_show_path(conn, :index) <> "{?page,per}",
           templated: true,
@@ -46,6 +46,18 @@ defmodule Jingle.API.RootView do
           title: "Get info for a single sponsor",
           profile: "http://meta.prx.org/model/sponsor",
           href: fix_path(api_sponsor_path(conn, :show, "{id}")),
+          templated: true,
+        }],
+        "prx:creatives": [%{
+          title: "Get a paged collection of creatives",
+          profile: "http://meta.prx.org/model/creative",
+          href: api_creative_path(conn, :index) <> "{?page,per}",
+          templated: true,
+        }],
+        "prx:creative": [%{
+          title: "Get info for a single creative",
+          profile: "http://meta.prx.org/model/creative",
+          href: fix_path(api_creative_path(conn, :show, "{id}")),
           templated: true,
         }],
 

--- a/web/views/api/show_view.ex
+++ b/web/views/api/show_view.ex
@@ -1,5 +1,3 @@
-require IEx
-
 defmodule Jingle.API.ShowView do
   use Jingle.Web, :view
 


### PR DESCRIPTION
#29, plus:  
- realized that the index route for nested resources was showing all resources, instead of those scoped to parent resource -- fixed that on all relevant controllers. 
- added one test each for controllers that had none. 
- commented out the authorization pipeline for now -- will handle that when we circle back to auth for jingle + adflow 