### PR TITLE
CI v2

### DIFF
--- a/.prxci
+++ b/.prxci
@@ -1,2 +1,0 @@
-docker-compose -f docker-compose-ci.yml build
-docker-compose -f docker-compose-ci.yml run jingle

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,20 @@
+version: 0.2
+env:
+  variables:
+    PRX_ECR_REGION: "us-east-1"
+    PRX_ECR_REPOSITORY: "jingle.prx.org"
+    PRX_ECR_CONFIG_PARAMETERS: "JingleEcrImageTag"
+phases:
+  install:
+    commands:
+      - 'echo "Installing docker-compose..."'
+      - 'COMPOSE="https://github.com/docker/compose/releases/download/1.11.2/docker-compose-$(uname -s)-$(uname -m)" && curl -sL $COMPOSE -o /usr/local/bin/docker-compose'
+      - "chmod +x /usr/local/bin/docker-compose"
+  build:
+    commands:
+      - "cd $(ls -d */|head -n 1)"
+      - "docker-compose -f docker-compose-ci.yml build"
+      - "docker-compose -f docker-compose-ci.yml run jingle"
+  post_build:
+    commands:
+      - 'curl -sO "https://raw.githubusercontent.com/PRX/Infrastructure/master/ci/utility/post_build.sh" && chmod +x post_build.sh && bash ./post_build.sh'


### PR DESCRIPTION
Per [documentation](https://github.com/PRX/Infrastructure/tree/master/ci), this PR: 
1. removes the .prxci file
2. adds a buildspec.yml that:
   a. sets the environmental variables needed by post_build.sh
   b. installs docker-compose
   c. runs the docker-compose commands previously known as .prxci
   d. runs the postbuild script

And I'm testing that it works by creating this pull request, which should trigger CodeBuild to look at buildspec.yml and try to run it. 