### PR TITLE
Use utc for timestamps

### DIFF
--- a/priv/repo/migrations/20171214195245_use_utc_for_timestamps.exs
+++ b/priv/repo/migrations/20171214195245_use_utc_for_timestamps.exs
@@ -1,0 +1,26 @@
+defmodule Jingle.Repo.Migrations.UseUtcForTimestamps do
+  use Ecto.Migration
+
+  def change do
+    alter table(:campaigns) do
+      modify :inserted_at, :utc_datetime
+      modify :updated_at, :utc_datetime
+    end
+
+    alter table(:sponsors) do
+      modify :inserted_at, :utc_datetime
+      modify :updated_at, :utc_datetime
+    end
+
+    alter table(:creatives) do
+      modify :inserted_at, :utc_datetime
+      modify :updated_at, :utc_datetime
+    end
+
+    alter table(:podcasts) do
+      modify :inserted_at, :utc_datetime
+      modify :updated_at, :utc_datetime
+    end
+
+  end
+end

--- a/priv/repo/migrations/20171214195245_use_utc_for_timestamps.exs
+++ b/priv/repo/migrations/20171214195245_use_utc_for_timestamps.exs
@@ -5,6 +5,7 @@ defmodule Jingle.Repo.Migrations.UseUtcForTimestamps do
     alter table(:campaigns) do
       modify :inserted_at, :utc_datetime
       modify :updated_at, :utc_datetime
+      modify :due_date, :utc_datetime
     end
 
     alter table(:sponsors) do


### PR DESCRIPTION
I ran into [this bug](https://github.com/PRX/publish.prx.org/issues/485) on adflow/spot as well after porting over the TimeAgo Pipe for use there. My fix on adflow/spot was to assume the updated_at was in UTC, and convert it toLocale before setting it as the updatedAt of the campaign model. But since then I've learned that Phoenix saves timestamps as "timestamp without time zone", and it's a little unpredictable what time zone it will actually represent. So I think it might be best to just cast them as UTC all the time. But -- open to other suggestions! 